### PR TITLE
Safer transfer of ETH

### DIFF
--- a/packages/hardhat/contracts/Distributor.sol
+++ b/packages/hardhat/contracts/Distributor.sol
@@ -111,8 +111,9 @@ contract Distributor {
                         );
                     }
                 } else {
-                    // transfer ETH otherwise
-                    payable(users[i]).transfer(shares[i]);
+                    // transfer ETH otherwise (we do not care if the transfer is successful 
+                    // or not, as this would block all other transfers)
+                    users[i].call{value: shares[i]}("");
                 }
             }
         }


### PR DESCRIPTION
I am thinking that we ignore whether the eth transfer succeeded or not so that we do not block payouts for all users. @carletex what do you think? 

My thinking: its the user's fault if they use a sketchy contract as the receiver 😝 